### PR TITLE
Feature: FancyHolograms Command Improvements

### DIFF
--- a/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
@@ -8,17 +8,22 @@ import org.bukkit.command.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 public class FancyHologramsCMD implements CommandExecutor, TabCompleter {
 
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if(args.length == 1){
-            return Stream.of("version", "reload", "save").filter(input -> input.toLowerCase().startsWith(args[0])).toList();
+        if (args.length != 1) {
+            return Collections.emptyList();
         }
-        return null;
+
+        return Stream.of("version", "reload", "save")
+                     .filter(alias -> alias.startsWith(args[0].toLowerCase(Locale.ROOT)))
+                     .toList();
     }
 
     @Override

--- a/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 public class FancyHologramsCMD implements CommandExecutor, TabCompleter {
@@ -28,30 +29,46 @@ public class FancyHologramsCMD implements CommandExecutor, TabCompleter {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-
-        if(args.length == 1 && args[0].equalsIgnoreCase("version")){
-            MessageHelper.info(sender, "<i>Checking version, please wait...</i>");
-            new Thread(() -> {
-                ComparableVersion newestVersion = FancyHolograms.getInstance().getVersionFetcher().getNewestVersion();
-                ComparableVersion currentVersion = new ComparableVersion(FancyHolograms.getInstance().getDescription().getVersion());
-                if(newestVersion == null){
-                    MessageHelper.error(sender, "Could not find latest version");
-                } else if(newestVersion.compareTo(currentVersion) > 0){
-                    MessageHelper.warning(sender, "You are using an outdated version of the FancyHolograms Plugin");
-                    MessageHelper.warning(sender, "[!] Please download the newest version (" + newestVersion + "): <click:open_url:'" + FancyHolograms.getInstance().getVersionFetcher().getDownloadUrl() + "'><u>click here</u></click>");
-                } else {
-                    MessageHelper.success(sender, "You are using the latest version of the FancyHolograms Plugin (" + currentVersion + ")");
-                }
-            }).start();
-        } else if(args.length == 1 && args[0].equalsIgnoreCase("reload")){
-            FancyHolograms.getInstance().getFancyHologramsConfig().reload();
-            FancyHolograms.getInstance().getHologramManager().reloadHolograms();
-            MessageHelper.success(sender, "Reloaded config and holograms");
-        } else if(args.length == 1 && args[0].equalsIgnoreCase("save")){
-            FancyHolograms.getInstance().getHologramManager().saveHolograms(true);
-            MessageHelper.success(sender, "Saved all holograms");
+        if (args.length != 1) {
+            return false;
         }
 
-        return false;
+        final var plugin = FancyHolograms.getInstance();
+
+        switch (args[0].toLowerCase(Locale.ROOT)) {
+            case "save" -> {
+                plugin.getHologramManager().saveHolograms(true);
+                MessageHelper.success(sender, "Saved all holograms");
+            }
+            case "reload" -> {
+                plugin.getFancyHologramsConfig().reload();
+                plugin.getHologramManager().reloadHolograms();
+                MessageHelper.success(sender, "Reloaded config and holograms");
+            }
+            case "version" -> {
+                MessageHelper.info(sender, "<i>Checking version, please wait...</i>");
+
+                final var fetcher = plugin.getVersionFetcher();
+                final var current = new ComparableVersion(plugin.getDescription().getVersion());
+
+                CompletableFuture.supplyAsync(fetcher::getNewestVersion).whenComplete((newest, error) -> {
+                    if (newest == null || error != null) {
+                        MessageHelper.error(sender, "Could not find latest version");
+                    } else if (newest.compareTo(current) > 0) {
+                        MessageHelper.warning(sender, """
+                                                      You are using an outdated version of the FancyHolograms Plugin
+                                                      [!] Please download the newest version (%s): <click:open_url:'%s'><u>click here</u></click>
+                                                      """.formatted(newest, fetcher.getDownloadUrl()));
+                    } else {
+                        MessageHelper.success(sender, "You are using the latest version of the FancyHolograms Plugin (" + current + ")");
+                    }
+                });
+            }
+            default -> {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
@@ -2,7 +2,6 @@ package de.oliver.fancyholograms.commands;
 
 import de.oliver.fancyholograms.FancyHolograms;
 import de.oliver.fancylib.MessageHelper;
-import de.oliver.fancynpcs.FancyNpcs;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.bukkit.command.*;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
@@ -5,7 +5,6 @@ import de.oliver.fancylib.MessageHelper;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.bukkit.command.*;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
@@ -13,10 +12,10 @@ import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
-public class FancyHologramsCMD implements CommandExecutor, TabCompleter {
+public final class FancyHologramsCMD implements CommandExecutor, TabCompleter {
 
     @Override
-    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+    public @NotNull List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         if (args.length != 1) {
             return Collections.emptyList();
         }
@@ -70,4 +69,5 @@ public class FancyHologramsCMD implements CommandExecutor, TabCompleter {
 
         return true;
     }
+
 }


### PR DESCRIPTION
This PR updates the `/fancyholograms` command in a couple of places...

#### updated tab completion to
- return an empty list instead of null
- properly suggest subcommands regardless of case

#### updated command executor to
- return early for incorrect args length
- properly return true/false for correct/incorrect usage
- use completable future instead of a thread
- use a text block instead of multiple messages