### PR TITLE
do not save deleted holograms

### DIFF
--- a/plugin/src/main/java/de/oliver/fancyholograms/FancyHologramsConfig.java
+++ b/plugin/src/main/java/de/oliver/fancyholograms/FancyHologramsConfig.java
@@ -132,14 +132,20 @@ public final class FancyHologramsConfig {
      * Saves holograms to the plugin's configuration based on the provided hologram data.
      *
      * @param holograms The collection of hologram data to save.
+     * @param force Indicates whether existing holograms collection should be replaced with this collection.
      */
-    public void saveHolograms(@NotNull @Unmodifiable final Collection<HologramData> holograms) {
+    public void saveHolograms(@NotNull @Unmodifiable final Collection<HologramData> holograms, final boolean force) {
         final var config = this.plugin.getConfig();
 
-        final var root = config.createSection("holograms");
+        final var root = (force == false && config.isConfigurationSection("holograms") == true)
+                ? config.getConfigurationSection("holograms")
+                : config.createSection("holograms");
 
         for (final var hologram : holograms) {
-            saveHologram(hologram, root.createSection(hologram.getName()));
+            saveHologram(hologram, (force == false && config.isConfigurationSection(hologram.getName()))
+                    ? root.getConfigurationSection(hologram.getName())
+                    : root.createSection(hologram.getName())
+            );
         }
 
         this.plugin.saveConfig();

--- a/plugin/src/main/java/de/oliver/fancyholograms/FancyHologramsConfig.java
+++ b/plugin/src/main/java/de/oliver/fancyholograms/FancyHologramsConfig.java
@@ -136,12 +136,10 @@ public final class FancyHologramsConfig {
     public void saveHolograms(@NotNull @Unmodifiable final Collection<HologramData> holograms) {
         final var config = this.plugin.getConfig();
 
-        final var root = ofNullable(config.getConfigurationSection("holograms"))
-                .orElseGet(() -> config.createSection("holograms"));
+        final var root = config.createSection("holograms");
 
         for (final var hologram : holograms) {
-            saveHologram(hologram, ofNullable(root.getConfigurationSection(hologram.getName()))
-                    .orElseGet(() -> root.createSection(hologram.getName())));
+            saveHologram(hologram, root.createSection(hologram.getName()));
         }
 
         this.plugin.saveConfig();

--- a/plugin/src/main/java/de/oliver/fancyholograms/FancyHologramsManager.java
+++ b/plugin/src/main/java/de/oliver/fancyholograms/FancyHologramsManager.java
@@ -156,12 +156,11 @@ public final class FancyHologramsManager {
 
     /**
      * Saves the holograms managed by this manager to the plugin's configuration.
+     *
+     * @param force Indicates whether existing holograms collection should be replaced with this collection.
      */
-    public void saveHolograms() {
-        this.plugin.getConfiguration()
-                .saveHolograms(getHolograms().stream()
-                        .map(Hologram::getData)
-                        .toList());
+    public void saveHolograms(final boolean force) {
+        this.plugin.getConfiguration().saveHolograms(getHolograms().stream().map(Hologram::getData).toList(), force);
     }
 
 

--- a/plugin/src/main/java/de/oliver/fancyholograms/FancyHologramsPlugin.java
+++ b/plugin/src/main/java/de/oliver/fancyholograms/FancyHologramsPlugin.java
@@ -100,9 +100,9 @@ public final class FancyHologramsPlugin extends JavaPlugin {
         getHologramsManager().initializeTasks();
 
         if (getConfiguration().isAutosaveEnabled()) {
-            getScheduler().runTaskTimerAsynchronously(getConfiguration().getAutosaveInterval() * 60L,
-                    getConfiguration().getAutosaveInterval() * 60L,
-                    getHologramsManager()::saveHolograms);
+            getScheduler().runTaskTimerAsynchronously(getConfiguration().getAutosaveInterval() * 60L, getConfiguration().getAutosaveInterval() * 60L, () -> {
+                    getHologramsManager().saveHolograms(true);
+            });
         }
     }
 
@@ -110,7 +110,7 @@ public final class FancyHologramsPlugin extends JavaPlugin {
     public void onDisable() {
         INSTANCE = null;
 
-        getHologramsManager().saveHolograms();
+        getHologramsManager().saveHolograms(true);
     }
 
     public @NotNull VersionFetcher getVersionFetcher() {

--- a/plugin/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
+++ b/plugin/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
@@ -35,7 +35,7 @@ public final class FancyHologramsCMD implements CommandExecutor, TabCompleter {
 
         switch (args[0].toLowerCase(Locale.ROOT)) {
             case "save" -> {
-                this.plugin.getHologramsManager().saveHolograms();
+                this.plugin.getHologramsManager().saveHolograms(true);
                 MessageHelper.success(sender, "Saved all holograms");
             }
             case "reload" -> {


### PR DESCRIPTION
Fixes an issue where holograms deleted with `/holo remove (name)` would re-appear after the server restart (and probably after config reload too).

This is now fixed by adding a `force` toggle to `FancyHologramsConfig#saveHolograms` method which indicates whether existing holograms collection should be replaced with provided collection. I set `force` parameter to `true` for all existing method references.