### PR TITLE
Add "/hologram search" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can download the latest versions at the following places:
 /FancyHolograms reload - Reloads the config and holograms<br>
 /Hologram help - Shows a list of all subcommands<br>
 /Hologram list - Shows a list of all holograms<br>
+/Hologram search (search term) - Searches for a hologram<br>
 /Hologram create (name) - Creates a new hologram at your location<br>
 /Hologram remove (hologram) - Removes a certain hologram<br>
 /Hologram copy (hologram) (new name) - Creates a copy of a hologram<br>

--- a/src/main/java/de/oliver/fancyholograms/commands/HologramCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/HologramCMD.java
@@ -101,6 +101,7 @@ public final class HologramCMD implements CommandExecutor, TabCompleter {
 
                 yield updated;
             }
+            case "search" -> new SearchCMD().run(player, hologram, args);
             default -> false;
         };
     }
@@ -113,7 +114,7 @@ public final class HologramCMD implements CommandExecutor, TabCompleter {
 
         // /holo {tab:action}
         if (args.length == 1) {
-            return Stream.of("help", "list", "teleport", "create", "remove", "edit", "copy")
+            return Stream.of("help", "list", "teleport", "create", "remove", "edit", "copy", "search")
                     .filter(input -> input.startsWith(args[0].toLowerCase(Locale.ROOT)))
                     .toList();
         }

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/SearchCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/SearchCMD.java
@@ -50,9 +50,9 @@ public class SearchCMD implements Subcommand {
             MessageHelper.info(player, "<b>Search results:</b>");
             MessageHelper.info(player, "<b>Page %s/%s</b>".formatted(page, pages));
             holograms.stream()
+                    .filter(holo -> holo.getData().getName().contains(search))
                     .skip((page - 1) * 10)
                     .limit(10)
-                    .filter(holo -> holo.getData().getName().contains(search))
                     .forEach(holo -> {
                         final var location = holo.getData().getDisplayData().getLocation();
                         if (location == null || location.getWorld() == null) {

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/SearchCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/SearchCMD.java
@@ -1,0 +1,75 @@
+package de.oliver.fancyholograms.commands.hologram;
+
+import com.google.common.primitives.Ints;
+import de.oliver.fancyholograms.FancyHolograms;
+import de.oliver.fancyholograms.api.Hologram;
+import de.oliver.fancyholograms.commands.Subcommand;
+import de.oliver.fancyholograms.util.Constants;
+import de.oliver.fancylib.MessageHelper;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class SearchCMD implements Subcommand {
+
+    @Override
+    public List<String> tabcompletion(@NotNull Player player, @Nullable Hologram hologram, @NotNull String[] args) {
+        return null;
+    }
+
+    @Override
+    public boolean run(@NotNull Player player, @Nullable Hologram hologram, @NotNull String[] args) {
+        final var holograms = FancyHolograms.get().getHologramsManager().getHolograms();
+
+        if (holograms.isEmpty()) {
+            MessageHelper.warning(player, "There are no holograms. Use '/hologram create' to create one");
+        } else {
+            int page;
+            String search = args[1];
+            if (args.length < 3) {
+                page = 1;
+            } else {
+                final var index = Ints.tryParse(args[2]);
+                if (index == null) {
+                    MessageHelper.error(player, "Could not parse page number");
+                    return false;
+                }
+                page = index;
+            }
+
+            var pages = holograms.stream()
+                    .filter(holo -> holo.getData().getName().contains(search))
+                    .count() / 10 + 1;
+
+            if (page > pages) {
+                MessageHelper.error(player, "Page %s does not exist".formatted(page));
+                return true;
+            }
+            MessageHelper.info(player, "<b>Search results:</b>");
+            MessageHelper.info(player, "<b>Page %s/%s</b>".formatted(page, pages));
+            holograms.stream()
+                    .skip((page - 1) * 10)
+                    .limit(10)
+                    .filter(holo -> holo.getData().getName().contains(search))
+                    .forEach(holo -> {
+                        final var location = holo.getData().getDisplayData().getLocation();
+                        if (location == null || location.getWorld() == null) {
+                            return;
+                        }
+
+                        MessageHelper.info(player,
+                                "<hover:show_text:'<gray><i>Click to teleport</i></gray>'><click:run_command:'%s'> - %s (%s/%s/%s)</click></hover>"
+                                        .formatted("/hologram teleport " + holo.getData().getName(),
+                                                holo.getData().getName(),
+                                                Constants.DECIMAL_FORMAT.format(location.x()),
+                                                Constants.DECIMAL_FORMAT.format(location.y()),
+                                                Constants.DECIMAL_FORMAT.format(location.z())));
+                    });
+
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/de/oliver/fancyholograms/util/Constants.java
+++ b/src/main/java/de/oliver/fancyholograms/util/Constants.java
@@ -16,6 +16,7 @@ public enum Constants {
             <%primary_color%><b>FancyHolograms commands help:<reset>
             <%primary_color%>- /hologram help <dark_gray>- <white>Shows all (sub)commands
             <%primary_color%>- /hologram list <dark_gray>- <white>Shows you a overview of all holograms
+            <%primary_color%>- /hologram search <search term> <dark_gray>- <white>Searches for holograms
             <%primary_color%>- /hologram teleport <name> <dark_gray>- <white>Teleports you to a hologram
             <%primary_color%>- /hologram create <name> <dark_gray>- <white>Creates a new hologram
             <%primary_color%>- /hologram remove <name> <dark_gray>- <white>Removes a hologram


### PR DESCRIPTION
Adds a new command that allows filtering of the hologram list. The code is mostly identical to the ListCMD code, the most relevant addition being `.filter(holo -> holo.getData().getName().contains(search))` and the pages calculation.

![image](https://github.com/FancyMcPlugins/FancyHolograms/assets/6313946/02ae5c98-ec04-4272-92e3-f4b80a902863)
