### PR TITLE
Show & hide holograms on teleport

### DIFF
--- a/src/main/java/de/oliver/fancyholograms/listeners/PlayerListener.java
+++ b/src/main/java/de/oliver/fancyholograms/listeners/PlayerListener.java
@@ -4,10 +4,7 @@ import de.oliver.fancyholograms.FancyHolograms;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerChangedWorldEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerMoveEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.*;
 import org.jetbrains.annotations.NotNull;
 
 public final class PlayerListener implements Listener {
@@ -49,6 +46,25 @@ public final class PlayerListener implements Listener {
             return; // reduce checks we need to do
         }
 
+        for (final var hologram : this.plugin.getHologramsManager().getHolograms()) {
+            final var distance = hologram.distanceTo(event.getTo());
+            if (Double.isNaN(distance)) {
+                continue;
+            }
+
+            final var inRange = distance <= hologram.getData().getDisplayData().getVisibilityDistance();
+            final var isShown = hologram.isShown(event.getPlayer());
+
+            if (inRange && !isShown) {
+                hologram.showHologram(event.getPlayer());
+            } else if (!inRange && isShown) {
+                hologram.hideHologram(event.getPlayer());
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onTeleport(@NotNull final PlayerTeleportEvent event) {
         for (final var hologram : this.plugin.getHologramsManager().getHolograms()) {
             final var distance = hologram.distanceTo(event.getTo());
             if (Double.isNaN(distance)) {


### PR DESCRIPTION
I noticed an issue with holograms not showing up when teleporting near them - you have to move (for the move event to trigger) to activate them.

We could refactor this to use more or less the same code as "on move", that is up to you in future.