### PR TITLE
replace PlayerMoveEvent with scheduler

### DIFF
--- a/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
+++ b/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
@@ -182,6 +182,14 @@ public final class HologramManagerImpl implements HologramManager {
                 updateTimes.put(hologram.getData().getName(), time);
             }
         });
+
+        this.plugin.getScheduler().runTaskTimerAsynchronously(20L, 20L, () -> {
+            for (final Hologram hologram : this.plugin.getHologramsManager().getHolograms()) {
+                for (final Player player : Bukkit.getOnlinePlayers()) {
+                    hologram.checkAndUpdateShownStateForPlayer(player);
+                }
+            }
+        });
     }
 
     /**

--- a/src/main/java/de/oliver/fancyholograms/listeners/PlayerListener.java
+++ b/src/main/java/de/oliver/fancyholograms/listeners/PlayerListener.java
@@ -40,17 +40,6 @@ public final class PlayerListener implements Listener {
         });
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onMove(@NotNull final PlayerMoveEvent event) {
-        if (!event.hasChangedBlock()) {
-            return; // reduce checks we need to do
-        }
-
-        for (final Hologram hologram : this.plugin.getHologramsManager().getHolograms()) {
-            hologram.checkAndUpdateShownStateForPlayer(event.getPlayer());
-        }
-    }
-
     @EventHandler(priority = EventPriority.MONITOR)
     public void onTeleport(@NotNull final PlayerTeleportEvent event) {
         for (final Hologram hologram : this.plugin.getHologramsManager().getHolograms()) {


### PR DESCRIPTION
PlayerMoveEvent should be replaced with a scheduler to reduce checks and the impact on the main thread
![image](https://github.com/FancyMcPlugins/FancyHolograms/assets/39985355/2fe0836c-0608-44cb-a59d-bdac98d6444d)
