### PR TITLE
fixes #139

### DIFF
--- a/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
+++ b/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
@@ -3,6 +3,7 @@ package de.oliver.fancyholograms;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import de.oliver.fancyholograms.api.HologramManager;
+import de.oliver.fancyholograms.api.data.DisplayHologramData;
 import de.oliver.fancyholograms.api.data.HologramData;
 import de.oliver.fancyholograms.api.data.TextHologramData;
 import de.oliver.fancyholograms.api.events.HologramsLoadedEvent;
@@ -14,6 +15,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
+import org.joml.Vector3f;
 
 import java.time.Duration;
 import java.util.*;
@@ -299,7 +301,13 @@ public final class HologramManagerImpl implements HologramManager {
         npc.getData().setShowInTab(false);
         npc.updateForAll();
 
-        final var location = npc.getData().getLocation().clone().add(0, npc.getEyeHeight() + 0.5, 0);
+        final var npcScale = npc.getData().getScale();
+
+        if(hologram.getData() instanceof DisplayHologramData displayData) {
+            displayData.setScale(new Vector3f(npcScale));
+        }
+
+        final var location = npc.getData().getLocation().clone().add(0, (npc.getEyeHeight() * npcScale) + (0.5 * npcScale), 0);
         hologram.getData().setLocation(location);
     }
 }

--- a/src/main/java/de/oliver/fancyholograms/listeners/NpcListener.java
+++ b/src/main/java/de/oliver/fancyholograms/listeners/NpcListener.java
@@ -34,7 +34,7 @@ public final class NpcListener implements Listener {
         final var holograms = this.plugin.getHologramsManager().getHolograms();
 
         switch (event.getModification()) {
-            case TYPE, LOCATION -> {
+            case TYPE, LOCATION, SCALE -> {
                 final var needsToBeUpdated = holograms.stream()
                         .filter(hologram -> event.getNpc().getData().getName().equals(hologram.getData().getLinkedNpcName()))
                         .toList();


### PR DESCRIPTION
Fixes npc linked holograms not updating properly with entity scale. This also implements a system where the hologram will also scale its size with the NPC.

Examples:

NPC Scale Of 2:
![NPC Scale Of 2](https://github.com/user-attachments/assets/aaf4cde3-5f65-4a56-b29f-3c6f24159329)

NPC Scale Of 0.1:
![image](https://github.com/user-attachments/assets/22449495-594a-4f9f-94e6-be4826434235)

