### PR TITLE
Use Bukkit's isPrimaryThread check to set event sync status

### DIFF
--- a/api/src/main/java/de/oliver/fancyholograms/api/events/HologramDeleteEvent.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/events/HologramDeleteEvent.java
@@ -1,6 +1,7 @@
 package de.oliver.fancyholograms.api.events;
 
 import de.oliver.fancyholograms.api.hologram.Hologram;
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;

--- a/api/src/main/java/de/oliver/fancyholograms/api/events/HologramHideEvent.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/events/HologramHideEvent.java
@@ -1,6 +1,7 @@
 package de.oliver.fancyholograms.api.events;
 
 import de.oliver.fancyholograms.api.hologram.Hologram;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -17,7 +18,7 @@ public final class HologramHideEvent extends HologramEvent {
     private final Player player;
 
     public HologramHideEvent(@NotNull final Hologram hologram, @NotNull final Player player) {
-        super(hologram, true);
+        super(hologram, !Bukkit.isPrimaryThread());
 
         this.player = player;
     }

--- a/api/src/main/java/de/oliver/fancyholograms/api/events/HologramShowEvent.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/events/HologramShowEvent.java
@@ -1,6 +1,7 @@
 package de.oliver.fancyholograms.api.events;
 
 import de.oliver.fancyholograms.api.hologram.Hologram;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -17,7 +18,7 @@ public final class HologramShowEvent extends HologramEvent {
     private final Player player;
 
     public HologramShowEvent(@NotNull final Hologram hologram, @NotNull final Player player) {
-        super(hologram, true);
+        super(hologram, !Bukkit.isPrimaryThread());
 
         this.player = player;
     }

--- a/api/src/main/java/de/oliver/fancyholograms/api/events/HologramsLoadedEvent.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/events/HologramsLoadedEvent.java
@@ -2,6 +2,7 @@ package de.oliver.fancyholograms.api.events;
 
 import com.google.common.collect.ImmutableList;
 import de.oliver.fancyholograms.api.hologram.Hologram;
+import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +14,7 @@ public final class HologramsLoadedEvent extends Event {
     private final ImmutableList<Hologram> holograms;
 
     public HologramsLoadedEvent(@NotNull final ImmutableList<Hologram> holograms) {
-        super(true);
+        super(!Bukkit.isPrimaryThread());
 
         this.holograms = holograms;
     }

--- a/api/src/main/java/de/oliver/fancyholograms/api/events/HologramsUnloadedEvent.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/events/HologramsUnloadedEvent.java
@@ -2,6 +2,7 @@ package de.oliver.fancyholograms.api.events;
 
 import com.google.common.collect.ImmutableList;
 import de.oliver.fancyholograms.api.hologram.Hologram;
+import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +14,7 @@ public final class HologramsUnloadedEvent extends Event {
     private final ImmutableList<Hologram> holograms;
 
     public HologramsUnloadedEvent(@NotNull final ImmutableList<Hologram> holograms) {
-        super(true);
+        super(!Bukkit.isPrimaryThread());
 
         this.holograms = holograms;
     }


### PR DESCRIPTION
Replaced the hardcoded `true` for asynchronous event handling with a dynamic `!Bukkit.isPrimaryThread()` check across all event constructors. This ensures events can be called synchronous or asynchronous based on the server thread context.