### PR TITLE
Made entity id accessible via Hologram

### DIFF
--- a/api/src/main/java/de/oliver/fancyholograms/api/hologram/Hologram.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/hologram/Hologram.java
@@ -54,6 +54,13 @@ public abstract class Hologram {
     }
 
     /**
+     * Returns the entity id of this hologram
+     * This id is for packet use only as the entity is not registered to the server
+     * @return entity id
+     */
+    public abstract int getEntityId();
+
+    /**
      * Returns the Display entity of this Hologram object.
      * The entity is not registered in the world or server.
      * Only use this method if you know what you're doing.

--- a/implementation_1_19_4/src/main/java/de/oliver/fancyholograms/hologram/version/Hologram1_19_4.java
+++ b/implementation_1_19_4/src/main/java/de/oliver/fancyholograms/hologram/version/Hologram1_19_4.java
@@ -46,6 +46,11 @@ public final class Hologram1_19_4 extends Hologram {
     }
 
     @Override
+    public int getEntityId() {
+        return display.getId();
+    }
+
+    @Override
     public @Nullable org.bukkit.entity.Display getDisplayEntity() {
         return display != null ? (org.bukkit.entity.Display) display.getBukkitEntity() : null;
     }

--- a/implementation_1_20_1/src/main/java/de/oliver/fancyholograms/hologram/version/Hologram1_20_1.java
+++ b/implementation_1_20_1/src/main/java/de/oliver/fancyholograms/hologram/version/Hologram1_20_1.java
@@ -46,6 +46,11 @@ public final class Hologram1_20_1 extends Hologram {
     }
 
     @Override
+    public int getEntityId() {
+        return display.getId();
+    }
+
+    @Override
     public @Nullable org.bukkit.entity.Display getDisplayEntity() {
         return display != null ? (org.bukkit.entity.Display) display.getBukkitEntity() : null;
     }

--- a/implementation_1_20_2/src/main/java/de/oliver/fancyholograms/hologram/version/Hologram1_20_2.java
+++ b/implementation_1_20_2/src/main/java/de/oliver/fancyholograms/hologram/version/Hologram1_20_2.java
@@ -46,6 +46,11 @@ public final class Hologram1_20_2 extends Hologram {
     }
 
     @Override
+    public int getEntityId() {
+        return display.getId();
+    }
+
+    @Override
     public @Nullable org.bukkit.entity.Display getDisplayEntity() {
         return display != null ? (org.bukkit.entity.Display) display.getBukkitEntity() : null;
     }

--- a/implementation_1_20_4/src/main/java/de/oliver/fancyholograms/hologram/version/Hologram1_20_4.java
+++ b/implementation_1_20_4/src/main/java/de/oliver/fancyholograms/hologram/version/Hologram1_20_4.java
@@ -46,6 +46,11 @@ public final class Hologram1_20_4 extends Hologram {
     }
 
     @Override
+    public int getEntityId() {
+        return display.getId();
+    }
+
+    @Override
     public @Nullable org.bukkit.entity.Display getDisplayEntity() {
         return display != null ? (org.bukkit.entity.Display) display.getBukkitEntity() : null;
     }

--- a/src/main/java/de/oliver/fancyholograms/hologram/version/HologramImpl.java
+++ b/src/main/java/de/oliver/fancyholograms/hologram/version/HologramImpl.java
@@ -20,6 +20,11 @@ public final class HologramImpl extends Hologram {
     }
 
     @Override
+    public int getEntityId() {
+        return fsDisplay.getId();
+    }
+
+    @Override
     public @Nullable org.bukkit.entity.Display getDisplayEntity() {
         return null;
     }


### PR DESCRIPTION
**Changelog:**
- Added `getEntityId` method to Hologram to allow for additional packet manipulation via the API