### PR TITLE
Config refactor + add option for disabling logging on world loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     compileOnly("de.oliver:FancyLib:36")
     compileOnly("de.oliver.FancyAnalytics:logger:0.0.6")
 
-    implementation("org.lushplugins:ChatColorHandler:5.1.2")
+    implementation("org.lushplugins:ChatColorHandler:5.1.3")
 }
 
 tasks {

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -9,7 +9,7 @@ val minecraftVersion = "1.19.4"
 dependencies {
     compileOnly("io.papermc.paper:paper-api:$minecraftVersion-R0.1-SNAPSHOT")
 
-    compileOnly("de.oliver:FancyLib:35")
+    compileOnly("de.oliver:FancyLib:36")
     compileOnly("de.oliver.FancyAnalytics:logger:0.0.6")
 
     implementation("org.lushplugins:ChatColorHandler:5.1.2")

--- a/api/src/main/java/de/oliver/fancyholograms/api/HologramConfiguration.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/HologramConfiguration.java
@@ -59,4 +59,11 @@ public interface HologramConfiguration {
      * @return The log level for the plugin.
      */
     String getLogLevel();
+
+    /**
+     * Returns the interval at which hologram visibility is updated.
+     *
+     * @return The hologram visibility update interval in milliseconds.
+     */
+    long getUpdateVisibilityInterval();
 }

--- a/api/src/main/java/de/oliver/fancyholograms/api/HologramConfiguration.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/HologramConfiguration.java
@@ -40,6 +40,13 @@ public interface HologramConfiguration {
     boolean isSaveOnChangedEnabled();
 
     /**
+     * Returns whether hologram load logging on world loading is enabled or disabled.
+     *
+     * @return {@code true} if hologram loading should be logged on world loading, {@code false} otherwise.
+     */
+    boolean isHologramLoadLogging();
+
+    /**
      * Returns the default visibility distance for holograms.
      *
      * @return The default hologram visibility distance.

--- a/api/src/main/java/de/oliver/fancyholograms/api/HologramConfiguration.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/HologramConfiguration.java
@@ -65,5 +65,5 @@ public interface HologramConfiguration {
      *
      * @return The hologram visibility update interval in milliseconds.
      */
-    long getUpdateVisibilityInterval();
+    int getUpdateVisibilityInterval();
 }

--- a/api/src/main/java/de/oliver/fancyholograms/api/HologramConfiguration.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/HologramConfiguration.java
@@ -12,13 +12,6 @@ public interface HologramConfiguration {
     void reload(@NotNull FancyHologramsPlugin plugin);
 
     /**
-     * Returns whether version notifications are muted.
-     *
-     * @return {@code true} if version notifications are muted, {@code false} otherwise.
-     */
-    boolean areVersionNotificationsMuted();
-
-    /**
      * Returns whether autosave is enabled.
      *
      * @return {@code true} if autosave is enabled, {@code false} otherwise.
@@ -40,6 +33,27 @@ public interface HologramConfiguration {
     boolean isSaveOnChangedEnabled();
 
     /**
+     * Returns the log level for the plugin.
+     *
+     * @return The log level for the plugin.
+     */
+    String getLogLevel();
+
+    /**
+     * Returns whether hologram load logging on world loading is enabled or disabled.
+     *
+     * @return {@code true} if hologram loading should be logged on world loading, {@code false} otherwise.
+     */
+    boolean isHologramLoadLogging();
+
+    /**
+     * Returns whether version notifications are enabled or disabled.
+     *
+     * @return {@code true} if version notifications are enabled, {@code false} otherwise.
+     */
+    boolean areVersionNotificationsEnabled();
+
+    /**
      * Returns the default visibility distance for holograms.
      *
      * @return The default hologram visibility distance.
@@ -53,10 +67,4 @@ public interface HologramConfiguration {
      */
     boolean isRegisterCommands();
 
-    /**
-     * Returns the log level for the plugin.
-     *
-     * @return The log level for the plugin.
-     */
-    String getLogLevel();
 }

--- a/api/src/main/java/de/oliver/fancyholograms/api/events/HologramDeleteEvent.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/events/HologramDeleteEvent.java
@@ -1,7 +1,6 @@
 package de.oliver.fancyholograms.api.events;
 
 import de.oliver.fancyholograms.api.hologram.Hologram;
-import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;

--- a/api/src/main/java/de/oliver/fancyholograms/api/events/HologramUpdateEvent.java
+++ b/api/src/main/java/de/oliver/fancyholograms/api/events/HologramUpdateEvent.java
@@ -82,7 +82,7 @@ public final class HologramUpdateEvent extends HologramEvent {
         SHADOW_RADIUS,
         SHADOW_STRENGTH,
         UPDATE_TEXT_INTERVAL,
-        UPDATE_VISIBILITY_DISTANCE;
+        UPDATE_VISIBILITY_DISTANCE
     }
 
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("xyz.jpenilla.run-paper") version "2.3.1"
     id("com.gradleup.shadow") version "8.3.6"
     id("net.minecrell.plugin-yml.paper") version "0.6.0"
-    id("io.papermc.hangar-publish-plugin") version "0.1.2"
+    id("io.papermc.hangar-publish-plugin") version "0.1.3"
     id("com.modrinth.minotaur") version "2.+"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
     implementation("de.oliver.FancyAnalytics:api:0.1.6")
     implementation("de.oliver.FancyAnalytics:logger:0.0.6")
 
-    compileOnly("de.oliver:FancyNpcs:2.4.2")
+    compileOnly("de.oliver:FancyNpcs:2.4.4")
     compileOnly("org.lushplugins:ChatColorHandler:5.1.2")
     compileOnly("org.geysermc.floodgate:api:2.2.4-SNAPSHOT")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ allprojects {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
 
     implementation(project(":api"))
     implementation(project(":implementation_1_20_4", configuration = "reobf"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
     implementation(project(":implementation_1_20_1", configuration = "reobf"))
     implementation(project(":implementation_1_19_4", configuration = "reobf"))
 
-    implementation("de.oliver:FancyLib:35")
+    implementation("de.oliver:FancyLib:36")
     implementation("de.oliver:FancySitula:0.0.13")
     implementation("de.oliver.FancyAnalytics:api:0.1.6")
     implementation("de.oliver.FancyAnalytics:logger:0.0.6")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     implementation("de.oliver.FancyAnalytics:logger:0.0.6")
 
     compileOnly("de.oliver:FancyNpcs:2.4.4")
-    compileOnly("org.lushplugins:ChatColorHandler:5.1.2")
+    compileOnly("org.lushplugins:ChatColorHandler:5.1.3")
     compileOnly("org.geysermc.floodgate:api:2.2.4-SNAPSHOT")
 }
 

--- a/implementation_1_19_4/build.gradle.kts
+++ b/implementation_1_19_4/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     paperweight.paperDevBundle("$minecraftVersion-R0.1-SNAPSHOT")
 
     implementation(project(":api"))
-    implementation("de.oliver:FancyLib:35")
+    implementation("de.oliver:FancyLib:36")
     compileOnly("com.viaversion:viaversion-api:5.2.1")
 }
 

--- a/implementation_1_19_4/build.gradle.kts
+++ b/implementation_1_19_4/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 
     implementation(project(":api"))
     implementation("de.oliver:FancyLib:36")
-    compileOnly("com.viaversion:viaversion-api:5.2.1")
+    compileOnly("com.viaversion:viaversion-api:5.3.0")
 }
 
 

--- a/implementation_1_20_1/build.gradle.kts
+++ b/implementation_1_20_1/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     paperweight.paperDevBundle("$minecraftVersion-R0.1-SNAPSHOT")
 
     implementation(project(":api"))
-    implementation("de.oliver:FancyLib:35")
+    implementation("de.oliver:FancyLib:36")
     compileOnly("com.viaversion:viaversion-api:5.2.1")
 }
 

--- a/implementation_1_20_1/build.gradle.kts
+++ b/implementation_1_20_1/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 
     implementation(project(":api"))
     implementation("de.oliver:FancyLib:36")
-    compileOnly("com.viaversion:viaversion-api:5.2.1")
+    compileOnly("com.viaversion:viaversion-api:5.3.0")
 }
 
 

--- a/implementation_1_20_2/build.gradle.kts
+++ b/implementation_1_20_2/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     paperweight.paperDevBundle("$minecraftVersion-R0.1-SNAPSHOT")
 
     implementation(project(":api"))
-    implementation("de.oliver:FancyLib:35")
+    implementation("de.oliver:FancyLib:36")
     compileOnly("com.viaversion:viaversion-api:5.2.1")
 }
 

--- a/implementation_1_20_2/build.gradle.kts
+++ b/implementation_1_20_2/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 
     implementation(project(":api"))
     implementation("de.oliver:FancyLib:36")
-    compileOnly("com.viaversion:viaversion-api:5.2.1")
+    compileOnly("com.viaversion:viaversion-api:5.3.0")
 }
 
 

--- a/implementation_1_20_4/build.gradle.kts
+++ b/implementation_1_20_4/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     paperweight.paperDevBundle("$minecraftVersion-R0.1-SNAPSHOT")
 
     implementation(project(":api"))
-    implementation("de.oliver:FancyLib:35")
+    implementation("de.oliver:FancyLib:36")
     compileOnly("com.viaversion:viaversion-api:5.2.1")
 }
 

--- a/implementation_1_20_4/build.gradle.kts
+++ b/implementation_1_20_4/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 
     implementation(project(":api"))
     implementation("de.oliver:FancyLib:36")
-    compileOnly("com.viaversion:viaversion-api:5.2.1")
+    compileOnly("com.viaversion:viaversion-api:5.3.0")
 }
 
 

--- a/src/main/java/de/oliver/fancyholograms/FancyHolograms.java
+++ b/src/main/java/de/oliver/fancyholograms/FancyHolograms.java
@@ -157,7 +157,7 @@ public final class FancyHolograms extends JavaPlugin implements FancyHologramsPl
         registerListeners();
 
         versionConfig.load();
-        if (!getHologramConfiguration().areVersionNotificationsMuted()) {
+        if (getHologramConfiguration().areVersionNotificationsEnabled()) {
             checkForNewerVersion();
         }
 
@@ -323,7 +323,7 @@ public final class FancyHolograms extends JavaPlugin implements FancyHologramsPl
 
         Metrics metrics = new Metrics(this, 17990);
         metrics.addCustomChart(new Metrics.SingleLineChart("total_holograms", () -> hologramsManager.getHolograms().size()));
-        metrics.addCustomChart(new Metrics.SimplePie("update_notifications", () -> configuration.areVersionNotificationsMuted() ? "No" : "Yes"));
+        metrics.addCustomChart(new Metrics.SimplePie("update_notifications", () -> configuration.areVersionNotificationsEnabled() ? "Yes" : "No"));
         metrics.addCustomChart(new Metrics.SimplePie("using_development_build", () -> isDevelopmentBuild ? "Yes" : "No"));
 
         fancyAnalytics = new FancyAnalyticsAPI("3b77bd59-2b01-46f2-b3aa-a9584401797f", "E2gW5zc2ZTk1OGFkNGY2ZDQ0ODlM6San");
@@ -363,7 +363,7 @@ public final class FancyHolograms extends JavaPlugin implements FancyHologramsPl
         }));
 
         fancyAnalytics.registerNumberMetric(new MetricSupplier<>("amount_holograms", () -> (double) hologramsManager.getHolograms().size()));
-        fancyAnalytics.registerStringMetric(new MetricSupplier<>("enabled_update_notifications", () -> configuration.areVersionNotificationsMuted() ? "false" : "true"));
+        fancyAnalytics.registerStringMetric(new MetricSupplier<>("enabled_update_notifications", () -> configuration.areVersionNotificationsEnabled() ? "true" : "false"));
         fancyAnalytics.registerStringMetric(new MetricSupplier<>("fflag_disable_holograms_for_bedrock_players", () -> FHFeatureFlags.DISABLE_HOLOGRAMS_FOR_BEDROCK_PLAYERS.isEnabled() ? "true" : "false"));
         fancyAnalytics.registerStringMetric(new MetricSupplier<>("using_development_build", () -> isDevelopmentBuild ? "true" : "false"));
 

--- a/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
+++ b/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
@@ -85,7 +85,8 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
             CONFIG_LOG_ON_WORLD_LOAD, List.of("Whether hologram loading should be logged on world loading. Disable this if you load worlds dynamically to prevent console spam."),
             CONFIG_VERSION_NOTIFICATIONS, List.of("Whether the plugin should send notifications for new updates."),
             CONFIG_VISIBILITY_DISTANCE, List.of("The default visibility distance for holograms."),
-            CONFIG_REGISTER_COMMANDS, List.of("Whether the plugin should register its commands.")
+            CONFIG_REGISTER_COMMANDS, List.of("Whether the plugin should register its commands."),
+            CONFIG_UPDATE_VISIBILITY_INTERVAL, List.of("The interval at which hologram visibility is updated in ticks.")
     );
 
     private void updateChecker(@NotNull FancyHolograms plugin, @NotNull FileConfiguration config) {
@@ -153,6 +154,7 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
         // options
         defaultVisibilityDistance = (int) ConfigHelper.getOrDefault(config, CONFIG_VISIBILITY_DISTANCE, 20);
         registerCommands = (boolean) ConfigHelper.getOrDefault(config, CONFIG_REGISTER_COMMANDS, true);
+        updateVisibilityInterval = (int) ConfigHelper.getOrDefault(config, CONFIG_UPDATE_VISIBILITY_INTERVAL, 100);
 
         config.set(CONFIG_REPORT_ERRORS_TO_SENTRY, null);
     }
@@ -213,4 +215,8 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
         return registerCommands;
     }
 
+    @Override
+    public int getUpdateVisibilityInterval() {
+        return updateVisibilityInterval;
+    }
 }

--- a/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
+++ b/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
@@ -3,6 +3,7 @@ package de.oliver.fancyholograms;
 import de.oliver.fancyholograms.api.FancyHologramsPlugin;
 import de.oliver.fancyholograms.api.HologramConfiguration;
 import de.oliver.fancylib.ConfigHelper;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -33,7 +34,6 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
      */
     private boolean saveOnChangedEnabled;
     private static final String CONFIG_SAVE_ON_CHANGED = "saving.save_on_changed";
-
 
     /**
      * The log level for the plugin.
@@ -70,98 +70,94 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
     private static final String CONFIG_REPORT_ERRORS_TO_SENTRY = "logging.report_errors_to_sentry";
     private static final String CONFIG_VERSION = "config_version";
 
-    @Override
-    public void reload(@NotNull FancyHologramsPlugin plugin) {
-        FancyHolograms pluginImpl = (FancyHolograms) plugin;
-        pluginImpl.reloadConfig();
+    private static final Map<String, List<String>> CONFIG_COMMENTS = Map.of(
+            CONFIG_VERSION, List.of("Config version, do not modify."),
+            CONFIG_AUTOSAVE_ENABLED, List.of("Whether autosave is enabled."),
+            CONFIG_AUTOSAVE_INTERVAL, List.of("The interval at which autosave is performed in minutes."),
+            CONFIG_SAVE_ON_CHANGED, List.of("Whether the plugin should save holograms when they are changed."),
+            CONFIG_LOG_LEVEL, List.of("The log level for the plugin (DEBUG, INFO, WARN, ERROR)."),
+            CONFIG_LOG_ON_WORLD_LOAD, List.of("Whether hologram loading should be logged on world loading. Disable this if you load worlds dynamically to prevent console spam."),
+            CONFIG_VERSION_NOTIFICATIONS, List.of("Whether the plugin should send notifications for new updates."),
+            CONFIG_VISIBILITY_DISTANCE, List.of("The default visibility distance for holograms."),
+            CONFIG_REGISTER_COMMANDS, List.of("Whether the plugin should register its commands.")
+    );
 
-        final var config = pluginImpl.getConfig();
-
+    private void updateChecker(@NotNull FancyHolograms plugin, @NotNull FileConfiguration config) {
         final int latestVersion = 1;
         int configVersion = (int) ConfigHelper.getOrDefault(config, CONFIG_VERSION, 0);
 
-        if (configVersion < latestVersion ) {
-
-            try {
-                pluginImpl.getFancyLogger().warn("Outdated config detected! Attempting to migrate previous settings to new config...");
-
-                var oldConfig = pluginImpl.getConfig();
-                File backupFile = new File(pluginImpl.getDataFolder(), "config_old.yml");
-                if (backupFile.exists() && !backupFile.canWrite()) {
-                    throw new IOException("Unable to backup config to " + backupFile.getPath());
-                }
-                oldConfig.save(backupFile);
-
-                pluginImpl.saveDefaultConfig();
-                var newConfig = pluginImpl.getConfig();
-
-                Map<String, Object> oldConfigValues = oldConfig.getValues(true);
-                oldConfigValues.forEach((key, value) -> {
-
-                    Map<String, String> keyMap = Map.of(
-                            "enable_autosave", CONFIG_AUTOSAVE_ENABLED,
-                            "autosave_interval", CONFIG_AUTOSAVE_INTERVAL,
-                            "save_on_changed", CONFIG_SAVE_ON_CHANGED,
-                            "log_level", CONFIG_LOG_LEVEL,
-                            "mute_version_notifications", CONFIG_VERSION_NOTIFICATIONS
-                    );
-
-                    String newKey = keyMap.getOrDefault(key, null);
-                    if (newKey != null) {
-                        if (newKey.equals(CONFIG_VERSION_NOTIFICATIONS)) {
-                            newConfig.set(newKey, !(Boolean) value);
-                        } else {
-                            newConfig.set(newKey, value);
-                        }
-                    } else if (newConfig.contains(key)) {
-                        newConfig.set(key, value);
-                    } else {
-                        pluginImpl.getFancyLogger().warn("> CONFIG: Option '" + key + "' is deprecated/invalid! Please migrate this manually from config_old.yml");
-                        return;
-                    }
-
-                    pluginImpl.getFancyLogger().info("> CONFIG: Set option '" + key + "' to '" + value + "' from old config.");
-                });
-
-                newConfig.set(CONFIG_VERSION, latestVersion);
-                pluginImpl.getFancyLogger().info("Configuration has finished migrating. Please double check your settings in config.yml.");
-
-            } catch (IOException e) {
-                pluginImpl.getFancyLogger().error("Failed to save or reload configuration: " + e.getMessage());
-            }
+        if (configVersion >= latestVersion ) {
+            setOptions(config);
+            return;
         }
+            plugin.getFancyLogger().warn("Outdated config detected! Attempting to migrate previous settings to new config...");
 
-        config.setInlineComments(CONFIG_VERSION, List.of("Config version, do not modify."));
+            var oldConfig = plugin.getConfig();
+            try {
+                File backupFile = new File(plugin.getDataFolder(), "config_old.yml");
+                oldConfig.save(backupFile);
+            } catch (IOException e) {
+                plugin.getFancyLogger().warn("Unable to backup config to config_old.yml:" + e);
+            }
+
+
+            var newConfig = plugin.getConfig();
+
+            Map<String, Object> oldConfigValues = oldConfig.getValues(true);
+            Map<String, String> keyMap = Map.of(
+                    "enable_autosave", CONFIG_AUTOSAVE_ENABLED,
+                    "autosave_interval", CONFIG_AUTOSAVE_INTERVAL,
+                    "save_on_changed", CONFIG_SAVE_ON_CHANGED,
+                    "log_level", CONFIG_LOG_LEVEL,
+                    "mute_version_notifications", CONFIG_VERSION_NOTIFICATIONS
+            );
+
+            oldConfigValues.forEach((key, value) -> {
+
+                String newKey = keyMap.getOrDefault(key, null);
+                if (newKey != null) {
+                    if (newKey.equals(CONFIG_VERSION_NOTIFICATIONS)) {
+                        newConfig.set(newKey, !(Boolean) value);
+                    } else {
+                        newConfig.set(newKey, value);
+                    }
+                    plugin.getFancyLogger().info("> CONFIG: Set option '" + key + "' to '" + value + "' from old config.");
+                } else {
+                    plugin.getFancyLogger().warn("> CONFIG: Option '" + key + "' is deprecated/invalid! Please migrate this manually from config_old.yml");
+                }
+            });
+
+            newConfig.set(CONFIG_VERSION, latestVersion);
+            setOptions(newConfig);
+            CONFIG_COMMENTS.forEach(config::setInlineComments);
+
+            plugin.getFancyLogger().info("Configuration has finished migrating. Please double check your settings in config.yml.");
+    }
+
+    private void setOptions(@NotNull FileConfiguration config) {
 
         // saving
         autosaveEnabled = (boolean) ConfigHelper.getOrDefault(config, CONFIG_AUTOSAVE_ENABLED, true);
-        config.setInlineComments(CONFIG_AUTOSAVE_ENABLED, List.of("Whether autosave is enabled."));
-
         autosaveInterval = (int) ConfigHelper.getOrDefault(config, CONFIG_AUTOSAVE_INTERVAL, 15);
-        config.setInlineComments(CONFIG_AUTOSAVE_INTERVAL, List.of("The interval at which autosave is performed in minutes."));
-
         saveOnChangedEnabled = (boolean) ConfigHelper.getOrDefault(config, CONFIG_SAVE_ON_CHANGED, true);
-        config.setInlineComments(CONFIG_SAVE_ON_CHANGED, List.of("Whether the plugin should save holograms when they are changed."));
-
         // logging
         logLevel = (String) ConfigHelper.getOrDefault(config, CONFIG_LOG_LEVEL, "INFO");
-        config.setInlineComments(CONFIG_LOG_LEVEL, List.of("The log level for the plugin (DEBUG, INFO, WARN, ERROR)."));
-
         hologramLoadLogging = (boolean) ConfigHelper.getOrDefault(config, CONFIG_LOG_ON_WORLD_LOAD, true);
-        config.setInlineComments(CONFIG_LOG_ON_WORLD_LOAD, List.of("Whether hologram loading should be logged on world loading. Disable this if you load worlds dynamically to prevent console spam."));
-
         versionNotifs = (boolean) ConfigHelper.getOrDefault(config, CONFIG_VERSION_NOTIFICATIONS, true);
-        config.setInlineComments(CONFIG_VERSION_NOTIFICATIONS, List.of("Whether the plugin should send notifications for new updates."));
-
-        config.set(CONFIG_REPORT_ERRORS_TO_SENTRY, null);
-        config.setInlineComments(CONFIG_REPORT_ERRORS_TO_SENTRY, List.of());
-
         // options
         defaultVisibilityDistance = (int) ConfigHelper.getOrDefault(config, CONFIG_VISIBILITY_DISTANCE, 20);
-        config.setInlineComments(CONFIG_VISIBILITY_DISTANCE, List.of("The default visibility distance for holograms."));
-
         registerCommands = (boolean) ConfigHelper.getOrDefault(config, CONFIG_REGISTER_COMMANDS, true);
-        config.setInlineComments(CONFIG_REGISTER_COMMANDS, List.of("Whether the plugin should register its commands."));
+
+        config.set(CONFIG_REPORT_ERRORS_TO_SENTRY, null);
+    }
+
+    @Override
+    public synchronized void reload(@NotNull FancyHologramsPlugin plugin) {
+        FancyHolograms pluginImpl = (FancyHolograms) plugin;
+        pluginImpl.reloadConfig();
+
+        var config = pluginImpl.getConfig();
+        updateChecker(pluginImpl, config);
 
         if (pluginImpl.isEnabled() && !plugin.getHologramThread().isShutdown()) {
             plugin.getHologramThread().submit(pluginImpl::saveConfig);

--- a/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
+++ b/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
@@ -14,11 +14,6 @@ import java.util.List;
 public final class FancyHologramsConfiguration implements HologramConfiguration {
 
     /**
-     * Indicates whether version notifications are muted.
-     */
-    private boolean versionNotifsMuted;
-
-    /**
      * Indicates whether autosave is enabled.
      */
     private boolean autosaveEnabled;
@@ -34,6 +29,21 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
     private boolean saveOnChangedEnabled;
 
     /**
+     * The log level for the plugin.
+     */
+    private String logLevel;
+
+    /**
+     * Indicates whether hologram loading should be logged on world loading.
+     */
+    private boolean hologramLoadLogging;
+
+    /**
+     * Indicates whether version notifications are enabled or disabled.
+     */
+    private boolean versionNotifs;
+
+    /**
      * The default visibility distance for holograms.
      */
     private int defaultVisibilityDistance;
@@ -45,11 +55,6 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
      */
     private boolean registerCommands;
 
-    /**
-     * The log level for the plugin.
-     */
-    private String logLevel;
-
     @Override
     public void reload(@NotNull FancyHologramsPlugin plugin) {
         FancyHolograms pluginImpl = (FancyHolograms) plugin;
@@ -57,29 +62,35 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
 
         final var config = pluginImpl.getConfig();
 
-        versionNotifsMuted = (boolean) ConfigHelper.getOrDefault(config, "mute_version_notification", false);
-        config.setInlineComments("mute_version_notification", List.of("Whether version notifications are muted."));
+        // saving
+        autosaveEnabled = (boolean) ConfigHelper.getOrDefault(config, "saving.autosave.enabled", true);
+        config.setInlineComments("saving.autosave.enabled", List.of("Whether autosave is enabled."));
 
-        autosaveEnabled = (boolean) ConfigHelper.getOrDefault(config, "enable_autosave", true);
-        config.setInlineComments("enable_autosave", List.of("Whether autosave is enabled."));
+        autosaveInterval = (int) ConfigHelper.getOrDefault(config, "saving.autosave.interval", 15);
+        config.setInlineComments("saving.autosave.interval", List.of("The interval at which autosave is performed in minutes."));
 
-        autosaveInterval = (int) ConfigHelper.getOrDefault(config, "autosave_interval", 15);
-        config.setInlineComments("autosave_interval", List.of("The interval at which autosave is performed in minutes."));
+        saveOnChangedEnabled = (boolean) ConfigHelper.getOrDefault(config, "saving.save_on_changed", true);
+        config.setInlineComments("saving.save_on_changed", List.of("Whether the plugin should save holograms when they are changed."));
 
-        saveOnChangedEnabled = (boolean) ConfigHelper.getOrDefault(config, "save_on_changed", true);
-        config.setInlineComments("save_on_changed", List.of("Whether the plugin should save holograms when they are changed."));
+        // logging
+        logLevel = (String) ConfigHelper.getOrDefault(config, "logging.log_level", "INFO");
+        config.setInlineComments("logging.log_level", List.of("The log level for the plugin (DEBUG, INFO, WARN, ERROR)."));
 
+        hologramLoadLogging = (boolean) ConfigHelper.getOrDefault(config, "logging.log_on_world_load", true);
+        config.setInlineComments("logging.log_on_world_load", List.of("Whether hologram loading should be logged on world loading. Disable this if you load worlds dynamically to prevent console spam."));
+
+        versionNotifs = (boolean) ConfigHelper.getOrDefault(config, "logging.version_notification", false);
+        config.setInlineComments("logging.version_notification", List.of("Whether the plugin should send notifications for new updates."));
+
+        config.set("logging.report_errors_to_sentry", null);
+        config.setInlineComments("logging.report_errors_to_sentry", null);
+
+        // options
         defaultVisibilityDistance = (int) ConfigHelper.getOrDefault(config, "visibility_distance", 20);
         config.setInlineComments("visibility_distance", List.of("The default visibility distance for holograms."));
 
         registerCommands = (boolean) ConfigHelper.getOrDefault(config, "register_commands", true);
         config.setInlineComments("register_commands", List.of("Whether the plugin should register its commands."));
-
-        config.set("report_errors_to_sentry", null);
-        config.setInlineComments("report_errors_to_sentry", null);
-
-        config.setInlineComments("log_level", List.of("The log level for the plugin (DEBUG, INFO, WARN, ERROR)."));
-        logLevel = (String) ConfigHelper.getOrDefault(config, "log_level", "INFO");
 
         if (pluginImpl.isEnabled()) {
             plugin.getHologramThread().submit(pluginImpl::saveConfig);
@@ -87,11 +98,6 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
             // Can't dispatch task if plugin is disabled
             pluginImpl.saveConfig();
         }
-    }
-
-    @Override
-    public boolean areVersionNotificationsMuted() {
-        return versionNotifsMuted;
     }
 
     @Override
@@ -110,6 +116,21 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
     }
 
     @Override
+    public String getLogLevel() {
+        return logLevel;
+    }
+
+    @Override
+    public boolean isHologramLoadLogging() {
+        return hologramLoadLogging;
+    }
+
+    @Override
+    public boolean areVersionNotificationsEnabled() {
+        return versionNotifs;
+    }
+
+    @Override
     public int getDefaultVisibilityDistance() {
         return defaultVisibilityDistance;
     }
@@ -119,7 +140,4 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
         return registerCommands;
     }
 
-    public String getLogLevel() {
-        return logLevel;
-    }
 }

--- a/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
+++ b/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
@@ -93,55 +93,55 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
         final int latestVersion = 1;
         int configVersion = (int) ConfigHelper.getOrDefault(config, CONFIG_VERSION, 0);
 
-        if (configVersion >= latestVersion ) {
+        if (configVersion >= latestVersion) {
             setOptions(config);
             return;
         }
-            plugin.getFancyLogger().warn("Outdated config detected! Attempting to migrate previous settings to new config...");
+        plugin.getFancyLogger().warn("Outdated config detected! Attempting to migrate previous settings to new config...");
 
-            try {
-                var oldConfig = pluginImpl.getConfig();
-                File backupFile = new File(pluginImpl.getDataFolder(), "config_old.yml");
-                if (backupFile.exists() && !backupFile.canWrite()) {
-                    throw new IOException("Unable to backup config to " + backupFile.getPath());
-                }
-                oldConfig.save(backupFile);
+        try {
+            var oldConfig = pluginImpl.getConfig();
+            File backupFile = new File(pluginImpl.getDataFolder(), "config_old.yml");
+            if (backupFile.exists() && !backupFile.canWrite()) {
+                throw new IOException("Unable to backup config to " + backupFile.getPath());
+            }
+            oldConfig.save(backupFile);
 
-                pluginImpl.saveDefaultConfig();
-                var newConfig = pluginImpl.getConfig();
+            pluginImpl.saveDefaultConfig();
+            var newConfig = pluginImpl.getConfig();
 
-                Map<String, Object> oldConfigValues = oldConfig.getValues(true);
-                Map<String, String> keyMap = Map.of(
+            Map<String, Object> oldConfigValues = oldConfig.getValues(true);
+            Map<String, String> keyMap = Map.of(
                     "enable_autosave", CONFIG_AUTOSAVE_ENABLED,
                     "autosave_interval", CONFIG_AUTOSAVE_INTERVAL,
                     "save_on_changed", CONFIG_SAVE_ON_CHANGED,
                     "log_level", CONFIG_LOG_LEVEL,
                     "mute_version_notifications", CONFIG_VERSION_NOTIFICATIONS
-                );
+            );
 
-                oldConfigValues.forEach((key, value) -> {
+            oldConfigValues.forEach((key, value) -> {
 
-                    String newKey = keyMap.getOrDefault(key, null);
-                    if (newKey != null) {
-                        if (newKey.equals(CONFIG_VERSION_NOTIFICATIONS)) {
-                            newConfig.set(newKey, !(Boolean) value);
-                        } else {
-                            newConfig.set(newKey, value);
-                        }
-                        plugin.getFancyLogger().info("> CONFIG: Set option '" + key + "' to '" + value + "' from old config.");
+                String newKey = keyMap.getOrDefault(key, null);
+                if (newKey != null) {
+                    if (newKey.equals(CONFIG_VERSION_NOTIFICATIONS)) {
+                        newConfig.set(newKey, !(Boolean) value);
                     } else {
-                        plugin.getFancyLogger().warn("> CONFIG: Option '" + key + "' is deprecated/invalid! Please migrate this manually from config_old.yml");
+                        newConfig.set(newKey, value);
                     }
-                });
+                    plugin.getFancyLogger().info("> CONFIG: Set option '" + key + "' to '" + value + "' from old config.");
+                } else {
+                    plugin.getFancyLogger().warn("> CONFIG: Option '" + key + "' is deprecated/invalid! Please migrate this manually from config_old.yml");
+                }
+            });
 
-                newConfig.set(CONFIG_VERSION, latestVersion);
-                setOptions(newConfig);
-                CONFIG_COMMENTS.forEach(config::setInlineComments);
+            newConfig.set(CONFIG_VERSION, latestVersion);
+            setOptions(newConfig);
+            CONFIG_COMMENTS.forEach(config::setInlineComments);
 
-                pluginImpl.getFancyLogger().info("Configuration has finished migrating. Please double check your settings in config.yml.");
+            pluginImpl.getFancyLogger().info("Configuration has finished migrating. Please double check your settings in config.yml.");
 
-            } catch (IOException e) {
-                pluginImpl.getFancyLogger().error("Failed to save or reload configuration: " + e.getMessage());
+        } catch (IOException e) {
+            pluginImpl.getFancyLogger().error("Failed to save or reload configuration: " + e.getMessage());
             }
     }
 

--- a/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
+++ b/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
@@ -50,6 +50,11 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
      */
     private String logLevel;
 
+    /**
+     * The interval at which hologram visibility is updated.
+     */
+    private long updateVisibilityInterval;
+
     @Override
     public void reload(@NotNull FancyHologramsPlugin plugin) {
         FancyHolograms pluginImpl = (FancyHolograms) plugin;
@@ -80,6 +85,9 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
 
         config.setInlineComments("log_level", List.of("The log level for the plugin (DEBUG, INFO, WARN, ERROR)."));
         logLevel = (String) ConfigHelper.getOrDefault(config, "log_level", "INFO");
+
+        updateVisibilityInterval = (long) ConfigHelper.getOrDefault(config, "update_visibility_interval", 20);
+        config.setInlineComments("update_visibility_interval", List.of("The interval at which hologram visibility is updated in ticks."));
 
         if (pluginImpl.isEnabled()) {
             plugin.getHologramThread().submit(pluginImpl::saveConfig);
@@ -119,7 +127,13 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
         return registerCommands;
     }
 
+    @Override
     public String getLogLevel() {
         return logLevel;
+    }
+
+    @Override
+    public long getUpdateVisibilityInterval() {
+        return updateVisibilityInterval;
     }
 }

--- a/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
+++ b/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
@@ -79,7 +79,7 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
         hologramLoadLogging = (boolean) ConfigHelper.getOrDefault(config, "logging.log_on_world_load", true);
         config.setInlineComments("logging.log_on_world_load", List.of("Whether hologram loading should be logged on world loading. Disable this if you load worlds dynamically to prevent console spam."));
 
-        versionNotifs = (boolean) ConfigHelper.getOrDefault(config, "logging.version_notification", false);
+        versionNotifs = (boolean) ConfigHelper.getOrDefault(config, "logging.version_notification", true);
         config.setInlineComments("logging.version_notification", List.of("Whether the plugin should send notifications for new updates."));
 
         config.set("logging.report_errors_to_sentry", null);

--- a/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
+++ b/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
@@ -62,18 +62,30 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
 
         final var config = pluginImpl.getConfig();
 
-        versionNotifsMuted = (boolean) ConfigHelper.getOrDefault(config, "mute_version_notification", false);
-        config.setInlineComments("mute_version_notification", List.of("Whether version notifications are muted."));
+        // saving
+        autosaveEnabled = (boolean) ConfigHelper.getOrDefault(config, "saving.autosave.enabled", true);
+        config.setInlineComments("saving.autosave.enabled", List.of("Whether autosave is enabled."));
 
-        autosaveEnabled = (boolean) ConfigHelper.getOrDefault(config, "enable_autosave", true);
-        config.setInlineComments("enable_autosave", List.of("Whether autosave is enabled."));
+        autosaveInterval = (int) ConfigHelper.getOrDefault(config, "saving.autosave.interval", 15);
+        config.setInlineComments("saving.autosave.interval", List.of("The interval at which autosave is performed in minutes."));
 
-        autosaveInterval = (int) ConfigHelper.getOrDefault(config, "autosave_interval", 15);
-        config.setInlineComments("autosave_interval", List.of("The interval at which autosave is performed in minutes."));
+        saveOnChangedEnabled = (boolean) ConfigHelper.getOrDefault(config, "saving.save_on_changed", true);
+        config.setInlineComments("saving.save_on_changed", List.of("Whether the plugin should save holograms when they are changed."));
 
-        saveOnChangedEnabled = (boolean) ConfigHelper.getOrDefault(config, "save_on_changed", true);
-        config.setInlineComments("save_on_changed", List.of("Whether the plugin should save holograms when they are changed."));
+        // logging
+        logLevel = (String) ConfigHelper.getOrDefault(config, "logging.log_level", "INFO");
+        config.setInlineComments("logging.log_level", List.of("The log level for the plugin (DEBUG, INFO, WARN, ERROR)."));
 
+        hologramLoadLogging = (boolean) ConfigHelper.getOrDefault(config, "logging.log_on_world_load", true);
+        config.setInlineComments("logging.log_on_world_load", List.of("Whether hologram loading should be logged on world loading. Disable this if you load worlds dynamically to prevent console spam."));
+
+        versionNotifs = (boolean) ConfigHelper.getOrDefault(config, "logging.version_notification", false);
+        config.setInlineComments("logging.version_notification", List.of("Whether the plugin should send notifications for new updates."));
+
+        config.set("logging.report_errors_to_sentry", null);
+        config.setInlineComments("logging.report_errors_to_sentry", null);
+
+        // options
         defaultVisibilityDistance = (int) ConfigHelper.getOrDefault(config, "visibility_distance", 20);
         config.setInlineComments("visibility_distance", List.of("The default visibility distance for holograms."));
 
@@ -115,6 +127,16 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
     @Override
     public boolean isSaveOnChangedEnabled() {
         return saveOnChangedEnabled;
+    }
+
+    @Override
+    public boolean isHologramLoadLogging() {
+        return hologramLoadLogging;
+    }
+
+    @Override
+    public boolean areVersionNotificationsEnabled() {
+        return versionNotifs;
     }
 
     @Override

--- a/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
+++ b/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
@@ -53,7 +53,7 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
     /**
      * The interval at which hologram visibility is updated.
      */
-    private long updateVisibilityInterval;
+    private int updateVisibilityInterval;
 
     @Override
     public void reload(@NotNull FancyHologramsPlugin plugin) {
@@ -86,7 +86,7 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
         config.setInlineComments("log_level", List.of("The log level for the plugin (DEBUG, INFO, WARN, ERROR)."));
         logLevel = (String) ConfigHelper.getOrDefault(config, "log_level", "INFO");
 
-        updateVisibilityInterval = (long) ConfigHelper.getOrDefault(config, "update_visibility_interval", 20);
+        updateVisibilityInterval = (int) ConfigHelper.getOrDefault(config, "update_visibility_interval", 20);
         config.setInlineComments("update_visibility_interval", List.of("The interval at which hologram visibility is updated in ticks."));
 
         if (pluginImpl.isEnabled()) {
@@ -133,7 +133,7 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
     }
 
     @Override
-    public long getUpdateVisibilityInterval() {
+    public int getUpdateVisibilityInterval() {
         return updateVisibilityInterval;
     }
 }

--- a/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
+++ b/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
@@ -5,7 +5,10 @@ import de.oliver.fancyholograms.api.HologramConfiguration;
 import de.oliver.fancylib.ConfigHelper;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The FancyHologramsConfig class is responsible for managing the configuration of the FancyHolograms plugin.
@@ -17,36 +20,44 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
      * Indicates whether autosave is enabled.
      */
     private boolean autosaveEnabled;
+    private static final String CONFIG_AUTOSAVE_ENABLED = "saving.autosave.enabled";
 
     /**
      * The interval at which autosave is performed.
      */
     private int autosaveInterval;
+    private static final String CONFIG_AUTOSAVE_INTERVAL = "saving.autosave.interval";
 
     /**
      * Indicates whether the plugin should save holograms when they are changed.
      */
     private boolean saveOnChangedEnabled;
+    private static final String CONFIG_SAVE_ON_CHANGED = "saving.save_on_changed";
+
 
     /**
      * The log level for the plugin.
      */
     private String logLevel;
+    private static final String CONFIG_LOG_LEVEL = "logging.log_level";
 
     /**
      * Indicates whether hologram loading should be logged on world loading.
      */
     private boolean hologramLoadLogging;
+    private static final String CONFIG_LOG_ON_WORLD_LOAD = "logging.log_on_world_load";
 
     /**
      * Indicates whether version notifications are enabled or disabled.
      */
     private boolean versionNotifs;
+    private static final String CONFIG_VERSION_NOTIFICATIONS = "logging.version_notifications";
 
     /**
      * The default visibility distance for holograms.
      */
     private int defaultVisibilityDistance;
+    private static final String CONFIG_VISIBILITY_DISTANCE = "visibility_distance";
 
     /**
      * Indicates whether commands should be registered.
@@ -54,6 +65,10 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
      * This is useful for users who want to use the plugin's API only.
      */
     private boolean registerCommands;
+    private static final String CONFIG_REGISTER_COMMANDS = "register_commands";
+
+    private static final String CONFIG_REPORT_ERRORS_TO_SENTRY = "logging.report_errors_to_sentry";
+    private static final String CONFIG_VERSION = "config_version";
 
     @Override
     public void reload(@NotNull FancyHologramsPlugin plugin) {
@@ -62,37 +77,93 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
 
         final var config = pluginImpl.getConfig();
 
+        final int latestVersion = 1;
+        int configVersion = (int) ConfigHelper.getOrDefault(config, CONFIG_VERSION, 0);
+
+        if (configVersion < latestVersion ) {
+
+            try {
+                pluginImpl.getFancyLogger().warn("Outdated config detected! Attempting to migrate previous settings to new config...");
+
+                var oldConfig = pluginImpl.getConfig();
+                File backupFile = new File(pluginImpl.getDataFolder(), "config_old.yml");
+                if (backupFile.exists() && !backupFile.canWrite()) {
+                    throw new IOException("Unable to backup config to " + backupFile.getPath());
+                }
+                oldConfig.save(backupFile);
+
+                pluginImpl.saveDefaultConfig();
+                var newConfig = pluginImpl.getConfig();
+
+                Map<String, Object> oldConfigValues = oldConfig.getValues(true);
+                oldConfigValues.forEach((key, value) -> {
+
+                    Map<String, String> keyMap = Map.of(
+                            "enable_autosave", CONFIG_AUTOSAVE_ENABLED,
+                            "autosave_interval", CONFIG_AUTOSAVE_INTERVAL,
+                            "save_on_changed", CONFIG_SAVE_ON_CHANGED,
+                            "log_level", CONFIG_LOG_LEVEL,
+                            "mute_version_notifications", CONFIG_VERSION_NOTIFICATIONS
+                    );
+
+                    String newKey = keyMap.getOrDefault(key, null);
+                    if (newKey != null) {
+                        if (newKey.equals(CONFIG_VERSION_NOTIFICATIONS)) {
+                            newConfig.set(newKey, !(Boolean) value);
+                        } else {
+                            newConfig.set(newKey, value);
+                        }
+                    } else if (newConfig.contains(key)) {
+                        newConfig.set(key, value);
+                    } else {
+                        pluginImpl.getFancyLogger().warn("> CONFIG: Option '" + key + "' is deprecated/invalid! Please migrate this manually from config_old.yml");
+                        return;
+                    }
+
+                    pluginImpl.getFancyLogger().info("> CONFIG: Set option '" + key + "' to '" + value + "' from old config.");
+                });
+
+                newConfig.set(CONFIG_VERSION, latestVersion);
+                pluginImpl.getFancyLogger().info("Configuration has finished migrating. Please double check your settings in config.yml.");
+
+            } catch (IOException e) {
+                pluginImpl.getFancyLogger().error("Failed to save or reload configuration: " + e.getMessage());
+            }
+        }
+
+        config.setInlineComments(CONFIG_VERSION, List.of("Config version, do not modify."));
+
         // saving
-        autosaveEnabled = (boolean) ConfigHelper.getOrDefault(config, "saving.autosave.enabled", true);
-        config.setInlineComments("saving.autosave.enabled", List.of("Whether autosave is enabled."));
+        autosaveEnabled = (boolean) ConfigHelper.getOrDefault(config, CONFIG_AUTOSAVE_ENABLED, true);
+        config.setInlineComments(CONFIG_AUTOSAVE_ENABLED, List.of("Whether autosave is enabled."));
 
-        autosaveInterval = (int) ConfigHelper.getOrDefault(config, "saving.autosave.interval", 15);
-        config.setInlineComments("saving.autosave.interval", List.of("The interval at which autosave is performed in minutes."));
+        autosaveInterval = (int) ConfigHelper.getOrDefault(config, CONFIG_AUTOSAVE_INTERVAL, 15);
+        config.setInlineComments(CONFIG_AUTOSAVE_INTERVAL, List.of("The interval at which autosave is performed in minutes."));
 
-        saveOnChangedEnabled = (boolean) ConfigHelper.getOrDefault(config, "saving.save_on_changed", true);
-        config.setInlineComments("saving.save_on_changed", List.of("Whether the plugin should save holograms when they are changed."));
+        saveOnChangedEnabled = (boolean) ConfigHelper.getOrDefault(config, CONFIG_SAVE_ON_CHANGED, true);
+        config.setInlineComments(CONFIG_SAVE_ON_CHANGED, List.of("Whether the plugin should save holograms when they are changed."));
 
         // logging
-        logLevel = (String) ConfigHelper.getOrDefault(config, "logging.log_level", "INFO");
-        config.setInlineComments("logging.log_level", List.of("The log level for the plugin (DEBUG, INFO, WARN, ERROR)."));
+        logLevel = (String) ConfigHelper.getOrDefault(config, CONFIG_LOG_LEVEL, "INFO");
+        config.setInlineComments(CONFIG_LOG_LEVEL, List.of("The log level for the plugin (DEBUG, INFO, WARN, ERROR)."));
 
-        hologramLoadLogging = (boolean) ConfigHelper.getOrDefault(config, "logging.log_on_world_load", true);
-        config.setInlineComments("logging.log_on_world_load", List.of("Whether hologram loading should be logged on world loading. Disable this if you load worlds dynamically to prevent console spam."));
+        hologramLoadLogging = (boolean) ConfigHelper.getOrDefault(config, CONFIG_LOG_ON_WORLD_LOAD, true);
+        config.setInlineComments(CONFIG_LOG_ON_WORLD_LOAD, List.of("Whether hologram loading should be logged on world loading. Disable this if you load worlds dynamically to prevent console spam."));
 
-        versionNotifs = (boolean) ConfigHelper.getOrDefault(config, "logging.version_notification", true);
-        config.setInlineComments("logging.version_notification", List.of("Whether the plugin should send notifications for new updates."));
+        versionNotifs = (boolean) ConfigHelper.getOrDefault(config, CONFIG_VERSION_NOTIFICATIONS, true);
+        config.setInlineComments(CONFIG_VERSION_NOTIFICATIONS, List.of("Whether the plugin should send notifications for new updates."));
 
-        config.set("logging.report_errors_to_sentry", null);
-        config.setInlineComments("logging.report_errors_to_sentry", null);
+        config.set(CONFIG_REPORT_ERRORS_TO_SENTRY, null);
+        config.setInlineComments(CONFIG_REPORT_ERRORS_TO_SENTRY, List.of());
 
         // options
-        defaultVisibilityDistance = (int) ConfigHelper.getOrDefault(config, "visibility_distance", 20);
-        config.setInlineComments("visibility_distance", List.of("The default visibility distance for holograms."));
+        defaultVisibilityDistance = (int) ConfigHelper.getOrDefault(config, CONFIG_VISIBILITY_DISTANCE, 20);
+        config.setInlineComments(CONFIG_VISIBILITY_DISTANCE, List.of("The default visibility distance for holograms."));
 
-        registerCommands = (boolean) ConfigHelper.getOrDefault(config, "register_commands", true);
-        config.setInlineComments("register_commands", List.of("Whether the plugin should register its commands."));
+        registerCommands = (boolean) ConfigHelper.getOrDefault(config, CONFIG_REGISTER_COMMANDS, true);
+        config.setInlineComments(CONFIG_REGISTER_COMMANDS, List.of("Whether the plugin should register its commands."));
 
-        if (pluginImpl.isEnabled()) {
+        if (pluginImpl.isEnabled() && !plugin.getHologramThread().isShutdown()) {
             plugin.getHologramThread().submit(pluginImpl::saveConfig);
         } else {
             // Can't dispatch task if plugin is disabled

--- a/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
+++ b/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
@@ -47,7 +47,14 @@ public final class HologramManagerImpl implements HologramManager {
     HologramManagerImpl(@NotNull final FancyHolograms plugin, @NotNull final Function<HologramData, Hologram> adapter) {
         this.plugin = plugin;
         this.adapter = adapter;
+        hologramLoadLogging = plugin.getHologramConfiguration().isHologramLoadLogging();
     }
+
+    /**
+     * Whether hologram loading should be logged on world loading.
+     */
+    private final boolean hologramLoadLogging;
+
 
     /**
      * @return A read-only collection of loaded holograms.
@@ -156,7 +163,7 @@ public final class HologramManagerImpl implements HologramManager {
 
         FancyHolograms.get().getHologramThread().submit(() -> Bukkit.getPluginManager().callEvent(new HologramsLoadedEvent(ImmutableList.copyOf(allLoaded))));
 
-        FancyHolograms.get().getFancyLogger().info(String.format("Loaded %d holograms for all loaded worlds", allLoaded.size()));
+        if (hologramLoadLogging) FancyHolograms.get().getFancyLogger().info(String.format("Loaded %d holograms for all loaded worlds", allLoaded.size()));
     }
 
     public void loadHolograms(String world) {
@@ -167,7 +174,7 @@ public final class HologramManagerImpl implements HologramManager {
 
         Bukkit.getPluginManager().callEvent(new HologramsLoadedEvent(ImmutableList.copyOf(loaded)));
 
-        FancyHolograms.get().getFancyLogger().info(String.format("Loaded %d holograms for world %s", loaded.size(), world));
+        if (hologramLoadLogging) FancyHolograms.get().getFancyLogger().info(String.format("Loaded %d holograms for world %s", loaded.size(), world));
     }
 
     /**

--- a/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
+++ b/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
@@ -193,7 +193,7 @@ public final class HologramManagerImpl implements HologramManager {
                         hologram.forceUpdateShownStateFor(player);
                     }
                 }
-            }, 0, plugin.getHologramConfiguration().getUpdateVisibilityInterval() * 50, TimeUnit.MILLISECONDS);
+            }, 0, plugin.getHologramConfiguration().getUpdateVisibilityInterval() * 50L, TimeUnit.MILLISECONDS);
         });
 
         final var updateTimes = CacheBuilder.newBuilder()

--- a/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
+++ b/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
@@ -186,7 +186,7 @@ public final class HologramManagerImpl implements HologramManager {
                         hologram.forceUpdateShownStateFor(player);
                     }
                 }
-            }, 0, 1, TimeUnit.SECONDS);
+            }, 0, plugin.getHologramConfiguration().getUpdateVisibilityInterval() * 50, TimeUnit.MILLISECONDS);
         });
 
         final var updateTimes = CacheBuilder.newBuilder()

--- a/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
@@ -8,14 +8,11 @@ import de.oliver.fancyholograms.storage.converter.FHConversionRegistry;
 import de.oliver.fancyholograms.storage.converter.HologramConversionSession;
 import de.oliver.fancyholograms.util.Constants;
 import de.oliver.fancylib.MessageHelper;
-import de.oliver.fancylib.translations.message.Message;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 public final class FancyHologramsCMD extends Command {
 
@@ -29,7 +26,7 @@ public final class FancyHologramsCMD extends Command {
     }
 
     @Override
-    public boolean execute(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) {
+    public boolean execute(@NotNull CommandSender sender, @NotNull String label, String @NotNull [] args) {
         if (!testPermission(sender)) {
             return false;
         }
@@ -51,11 +48,7 @@ public final class FancyHologramsCMD extends Command {
 
                 MessageHelper.success(sender, "Reloaded config and holograms");
             }
-            case "version" -> {
-                FancyHolograms.get().getHologramThread().submit(() -> {
-                    FancyHolograms.get().getVersionConfig().checkVersionAndDisplay(sender, false);
-                });
-            }
+            case "version" -> FancyHolograms.get().getHologramThread().submit(() -> FancyHolograms.get().getVersionConfig().checkVersionAndDisplay(sender, false));
             case "convert" -> {
                 if (args.length < 3) {
                     MessageHelper.info(sender, "Usage: /fancyholograms convert <type> <targets> [args...]");
@@ -105,7 +98,7 @@ public final class FancyHologramsCMD extends Command {
     }
 
     @Override
-    public @NotNull List<String> tabComplete(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) throws IllegalArgumentException {
+    public @NotNull List<String> tabComplete(@NotNull CommandSender sender, @NotNull String label, String @NotNull [] args) throws IllegalArgumentException {
         if (args.length < 1) {
             return Collections.emptyList();
         }

--- a/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/FancyHologramsCMD.java
@@ -26,7 +26,7 @@ public final class FancyHologramsCMD extends Command {
     }
 
     @Override
-    public boolean execute(@NotNull CommandSender sender, @NotNull String label, String @NotNull [] args) {
+    public boolean execute(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) {
         if (!testPermission(sender)) {
             return false;
         }
@@ -98,7 +98,7 @@ public final class FancyHologramsCMD extends Command {
     }
 
     @Override
-    public @NotNull List<String> tabComplete(@NotNull CommandSender sender, @NotNull String label, String @NotNull [] args) throws IllegalArgumentException {
+    public @NotNull List<String> tabComplete(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) throws IllegalArgumentException {
         if (args.length < 1) {
             return Collections.emptyList();
         }

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/AddLineCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/AddLineCMD.java
@@ -29,12 +29,12 @@ public class AddLineCMD implements Subcommand {
             return false;
         }
 
-        String text = "";
+        StringBuilder text = new StringBuilder();
         for (int i = 3; i < args.length; i++) {
-            text += args[i] + " ";
+            text.append(args[i]).append(" ");
         }
-        text = text.substring(0, text.length() - 1);
+        text = new StringBuilder(text.substring(0, text.length() - 1));
 
-        return SetLineCMD.setLine(player, hologram, Integer.MAX_VALUE, text);
+        return SetLineCMD.setLine(player, hologram, Integer.MAX_VALUE, text.toString());
     }
 }

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/BrightnessCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/BrightnessCMD.java
@@ -46,7 +46,7 @@ public class BrightnessCMD implements Subcommand {
             return false;
         }
 
-        final var brightnessValue = parsedNumber.get();
+        final int brightnessValue = parsedNumber.get();
 
         if(brightnessValue < 0 || brightnessValue > 15) {
             MessageHelper.error(player, "Invalid brightness value, must be between 0 and 15");

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/CreateCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/CreateCMD.java
@@ -58,18 +58,7 @@ public class CreateCMD implements Subcommand {
             return false;
         }
 
-        DisplayHologramData displayData = null;
-        switch (type) {
-            case TEXT -> displayData = new TextHologramData(name, player.getLocation());
-            case ITEM -> {
-                displayData = new ItemHologramData(name, player.getLocation());
-                displayData.setBillboard(Display.Billboard.FIXED);
-            }
-            case BLOCK -> {
-                displayData = new BlockHologramData(name, player.getLocation());
-                displayData.setBillboard(Display.Billboard.FIXED);
-            }
-        }
+        DisplayHologramData displayData = getDisplayHologramData(player, type, name);
 
         final var holo = FancyHolograms.get().getHologramsManager().create(displayData);
         if (!new HologramCreateEvent(holo, player).callEvent()) {
@@ -87,4 +76,21 @@ public class CreateCMD implements Subcommand {
         MessageHelper.success(player, "Created the hologram");
         return true;
     }
+
+    private static @Nullable DisplayHologramData getDisplayHologramData(Player player, HologramType type, String name) {
+        DisplayHologramData displayData = null;
+        switch (type) {
+            case TEXT -> displayData = new TextHologramData(name, player.getLocation());
+            case ITEM -> {
+                displayData = new ItemHologramData(name, player.getLocation());
+                displayData.setBillboard(Display.Billboard.FIXED);
+            }
+            case BLOCK -> {
+                displayData = new BlockHologramData(name, player.getLocation());
+                displayData.setBillboard(Display.Billboard.FIXED);
+            }
+        }
+        return displayData;
+    }
+
 }

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/InfoCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/InfoCMD.java
@@ -51,30 +51,34 @@ public class InfoCMD implements Subcommand {
             MessageHelper.info(player, "Linked npc: <gray>" + data.getLinkedNpcName());
         }
 
-        if (data instanceof TextHologramData textData) {
-            MessageHelper.info(player, "Text: ");
-            for (String line : textData.getText()) {
-                MessageHelper.info(player, " <reset> " + line);
-            }
+        switch (data) {
+            case TextHologramData textData -> {
+                MessageHelper.info(player, "Text: ");
+                for (String line : textData.getText()) {
+                    MessageHelper.info(player, " <reset> " + line);
+                }
 
-            if (textData.getBackground() != null) {
-                MessageHelper.info(player, "Background: <gray>" + '#' + Integer.toHexString(textData.getBackground().asARGB()));
-            } else {
-                MessageHelper.info(player, "Background: <gray>default");
-            }
+                if (textData.getBackground() != null) {
+                    MessageHelper.info(player, "Background: <gray>" + '#' + Integer.toHexString(textData.getBackground().asARGB()));
+                } else {
+                    MessageHelper.info(player, "Background: <gray>default");
+                }
 
-            MessageHelper.info(player, "Text alignment: <gray>" + textData.getTextAlignment().name());
-            MessageHelper.info(player, "See through: <gray>" + (textData.isSeeThrough() ? "enabled" : "disabled"));
-            MessageHelper.info(player, "Text shadow: <gray>" + (textData.hasTextShadow() ? "enabled" : "disabled"));
-            if (textData.getTextUpdateInterval() == -1) {
-                MessageHelper.info(player, "Update text interval: <gray>not updating");
-            } else {
-                MessageHelper.info(player, "Update text interval: <gray>" + textData.getTextUpdateInterval() + " ticks");
+                MessageHelper.info(player, "Text alignment: <gray>" + textData.getTextAlignment().name());
+                MessageHelper.info(player, "See through: <gray>" + (textData.isSeeThrough() ? "enabled" : "disabled"));
+                MessageHelper.info(player, "Text shadow: <gray>" + (textData.hasTextShadow() ? "enabled" : "disabled"));
+                if (textData.getTextUpdateInterval() == -1) {
+                    MessageHelper.info(player, "Update text interval: <gray>not updating");
+                } else {
+                    MessageHelper.info(player, "Update text interval: <gray>" + textData.getTextUpdateInterval() + " ticks");
+                }
             }
-        } else if (data instanceof BlockHologramData blockData) {
-            MessageHelper.info(player, "Block: <gray>" + blockData.getBlock().name());
-        } else if (data instanceof ItemHologramData itemData) {
-            MessageHelper.info(player, "Item: <gray>" + itemData.getItemStack().getType().name());
+            case BlockHologramData blockData ->
+                    MessageHelper.info(player, "Block: <gray>" + blockData.getBlock().name());
+            case ItemHologramData itemData ->
+                    MessageHelper.info(player, "Item: <gray>" + itemData.getItemStack().getType().name());
+            default -> {
+            }
         }
 
         return true;

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/InsertAfterCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/InsertAfterCMD.java
@@ -46,9 +46,9 @@ public class InsertAfterCMD implements Subcommand {
             return false;
         }
 
-        String text = "";
+        StringBuilder text = new StringBuilder();
         for (int i = 4; i < args.length; i++) {
-            text += args[i] + " ";
+            text.append(args[i]).append(" ");
         }
 
         if (text.isEmpty()) {
@@ -56,10 +56,10 @@ public class InsertAfterCMD implements Subcommand {
             return true;
         }
 
-        text = text.substring(0, text.length() - 1);
+        text = new StringBuilder(text.substring(0, text.length() - 1));
 
         final var lines = new ArrayList<>(textData.getText());
-        lines.add(Math.min(index, lines.size()), text);
+        lines.add(Math.min(index, lines.size()), text.toString());
 
         final var copied = textData.copy(textData.getName());
         copied.setText(lines);

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/InsertBeforeCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/InsertBeforeCMD.java
@@ -48,9 +48,9 @@ public class InsertBeforeCMD implements Subcommand {
             return false;
         }
 
-        String text = "";
+        StringBuilder text = new StringBuilder();
         for (int i = 4; i < args.length; i++) {
-            text += args[i] + " ";
+            text.append(args[i]).append(" ");
         }
 
         if (text.isEmpty()) {
@@ -58,10 +58,10 @@ public class InsertBeforeCMD implements Subcommand {
             return true;
         }
 
-        text = text.substring(0, text.length() - 1);
+        text = new StringBuilder(text.substring(0, text.length() - 1));
 
         final var lines = new ArrayList<>(textData.getText());
-        lines.add(Math.min(index, lines.size()), text);
+        lines.add(Math.min(index, lines.size()), text.toString());
 
         final var copied = textData.copy(textData.getName());
         copied.setText(lines);

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/ListCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/ListCMD.java
@@ -52,7 +52,7 @@ public class ListCMD implements Subcommand {
             MessageHelper.info(player, "<b>List of holograms:</b>");
             MessageHelper.info(player, "<b>Page %s/%s</b>".formatted(page, pages));
             holograms.stream()
-                    .skip((page - 1) * 10)
+                    .skip((page - 1) * 10L)
                     .limit(10)
                     .forEach(holo -> {
                         final var location = holo.getData().getLocation();

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/SetLineCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/SetLineCMD.java
@@ -76,12 +76,12 @@ public class SetLineCMD implements Subcommand {
 
         index--;
 
-        String text = "";
+        StringBuilder text = new StringBuilder();
         for (int i = 4; i < args.length; i++) {
-            text += args[i] + " ";
+            text.append(args[i]).append(" ");
         }
-        text = text.substring(0, text.length() - 1);
+        text = new StringBuilder(text.substring(0, text.length() - 1));
 
-        return setLine(player, hologram, index, text);
+        return setLine(player, hologram, index, text.toString());
     }
 }

--- a/src/main/java/de/oliver/fancyholograms/commands/hologram/TextAlignmentCMD.java
+++ b/src/main/java/de/oliver/fancyholograms/commands/hologram/TextAlignmentCMD.java
@@ -60,7 +60,7 @@ public class TextAlignmentCMD implements Subcommand {
             return false;
         }
 
-        textData.setTextAlignment(((TextHologramData) copied).getTextAlignment());
+        textData.setTextAlignment(copied.getTextAlignment());
 
         if (FancyHolograms.get().getHologramConfiguration().isSaveOnChangedEnabled()) {
             FancyHolograms.get().getHologramStorage().save(hologram);

--- a/src/main/java/de/oliver/fancyholograms/listeners/PlayerListener.java
+++ b/src/main/java/de/oliver/fancyholograms/listeners/PlayerListener.java
@@ -2,7 +2,6 @@ package de.oliver.fancyholograms.listeners;
 
 import de.oliver.fancyholograms.FancyHolograms;
 import de.oliver.fancyholograms.api.hologram.Hologram;
-import net.kyori.adventure.resource.ResourcePackStatus;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -34,7 +33,7 @@ public final class PlayerListener implements Listener {
             hologram.updateShownStateFor(event.getPlayer());
         }
 
-        if (!this.plugin.getHologramConfiguration().areVersionNotificationsMuted() && event.getPlayer().hasPermission("fancyholograms.admin")) {
+        if (!this.plugin.getHologramConfiguration().areVersionNotificationsEnabled() && event.getPlayer().hasPermission("fancyholograms.admin")) {
             FancyHolograms.get().getHologramThread().submit(() -> FancyHolograms.get().getVersionConfig().checkVersionAndDisplay(event.getPlayer(), true));
         }
     }

--- a/src/main/java/de/oliver/fancyholograms/listeners/WorldListener.java
+++ b/src/main/java/de/oliver/fancyholograms/listeners/WorldListener.java
@@ -8,10 +8,12 @@ import org.bukkit.event.world.WorldUnloadEvent;
 
 public class WorldListener implements Listener {
 
+    private final boolean hologramLoadLogging = FancyHolograms.get().getHologramConfiguration().isHologramLoadLogging();
+
     @EventHandler
     public void onWorldLoad(WorldLoadEvent event) {
         FancyHolograms.get().getHologramThread().submit(() -> {
-            FancyHolograms.get().getFancyLogger().info("Loading holograms for world " + event.getWorld().getName());
+            if (hologramLoadLogging) FancyHolograms.get().getFancyLogger().info("Loading holograms for world " + event.getWorld().getName());
             FancyHolograms.get().getHologramsManager().loadHolograms(event.getWorld().getName());
         });
     }
@@ -19,7 +21,7 @@ public class WorldListener implements Listener {
     @EventHandler
     public void onWorldUnload(WorldUnloadEvent event) {
         FancyHolograms.get().getHologramThread().submit(() -> {
-            FancyHolograms.get().getFancyLogger().info("Unloading holograms for world " + event.getWorld().getName());
+            if (hologramLoadLogging) FancyHolograms.get().getFancyLogger().info("Unloading holograms for world " + event.getWorld().getName());
             FancyHolograms.get().getHologramsManager().unloadHolograms(event.getWorld().getName());
         });
     }

--- a/src/main/java/de/oliver/fancyholograms/storage/converter/HologramConversionSession.java
+++ b/src/main/java/de/oliver/fancyholograms/storage/converter/HologramConversionSession.java
@@ -2,10 +2,6 @@ package de.oliver.fancyholograms.storage.converter;
 
 import de.oliver.fancyholograms.api.data.HologramData;
 import de.oliver.fancylib.MessageHelper;
-import de.oliver.fancylib.translations.message.Message;
-import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;


### PR DESCRIPTION
This PR cleans up the configuration file, and adds the option to disable hologram loading log messages when worlds are loaded. The new config.yml is as follows:

```yaml
saving:
  autosave:
    enabled: true # Whether autosave is enabled.
    interval: 15 # The interval at which autosave is performed in minutes.
  save_on_changed: true # Whether the plugin should save holograms when they are changed.
logging:
  log_level: INFO # The log level for the plugin (DEBUG, INFO, WARN, ERROR).
  log_on_world_load: true # Whether hologram loading should be logged on world loading. Disable this if you load worlds dynamically to prevent console spam.
  version_notification: true # Whether the plugin should send notifications for new updates.
visibility_distance: 20 # The default visibility distance for holograms.
register_commands: true # Whether the plugin should register its commands.
```

This simply organizes the configuration for improved readability by nesting common options and ordering them properly. `mute_version_notifications` has been refactored to `logging.version_notifications` to make the option more intuitive (true = sends notifications, false = does not send notifications). All files and method names have been updated accordingly.

The option `logging.log_on_world_load` provides the ability to disable messages such as:
`[FancyHolograms] (FancyHolograms-Holograms) INFO: Loading holograms for <worldname>`
This allows server operators to prevent FancyHolograms from spamming console on servers that load/unload worlds dynamically (especially worlds that have no holograms, which makes these messages redundant).